### PR TITLE
Puppet.newtype is deprecated since puppet 4

### DIFF
--- a/lib/puppet/type/bsdportconfig.rb
+++ b/lib/puppet/type/bsdportconfig.rb
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(dir) unless $LOAD_PATH.include?(dir)
 require 'puppet/util/bsdportconfig'
 
 module Puppet
-  newtype(:bsdportconfig) do
+  Type.newtype(:bsdportconfig) do
     @doc = <<-DOC
 Set build options for BSD ports.
 


### PR DESCRIPTION
`Puppet.newtype` is deprecated since Puppet 4. `Puppet::Type.newtype` is supported at least since Puppet 3.8, so it should be ok to change that.